### PR TITLE
Improve worst case performance

### DIFF
--- a/i_dunno/__init__.py
+++ b/i_dunno/__init__.py
@@ -65,12 +65,10 @@ def bits_to_bytes(bits):
     return bytes(sum(bit << (7 - idx) for idx, bit in enumerate(aligned_bits[sidx:sidx + 8])) for sidx in range(0, len(aligned_bits), 8))
 
 
-@functools.lru_cache
 def packed_combinations(bits, lengths):
     if not bits:
-        return [b'']
-
-    bytestrs = []
+        yield b''
+        return
 
     for minimum, length in lengths:
         if len(bits) < length:
@@ -90,11 +88,9 @@ def packed_combinations(bits, lengths):
             try:
                 bytestr = part + combination
                 bytestr.decode('utf-8')
-                bytestrs.append(bytestr)
+                yield(bytestr)
             except UnicodeDecodeError:
                 continue
-
-    return bytestrs
 
 
 def confusion_check(bytestr, level, levels, constraints):
@@ -124,7 +120,7 @@ def encode(addr, level='minimum'):
 
     bits = bytes_to_bits(addr.packed)
 
-    bytestrs = packed_combinations(tuple(bits), tuple(utf8_lengths))
+    bytestrs = list(packed_combinations(tuple(bits), tuple(utf8_lengths)))
     random.shuffle(bytestrs)
 
     for bytestr in bytestrs:

--- a/i_dunno/__init__.py
+++ b/i_dunno/__init__.py
@@ -125,12 +125,11 @@ def encode(addr, level='minimum'):
         packed_combinations(tuple(bits), tuple(utf8_lengths))
     )
     bytestrs = list(candidates)
-    random.shuffle(bytestrs)
 
-    for bytestr in bytestrs:
-        return bytestr
-
-    raise ValueError(f'could not represent given address "{addr}" as valid I-DUNNO at confusion level "{level}"')
+    if len(bytestrs) > 0:
+        return random.choice(bytestrs)
+    else:
+        raise ValueError(f'could not represent given address "{addr}" as valid I-DUNNO at confusion level "{level}"')
 
 
 def decode(i_dunno):

--- a/i_dunno/__init__.py
+++ b/i_dunno/__init__.py
@@ -120,12 +120,15 @@ def encode(addr, level='minimum'):
 
     bits = bytes_to_bits(addr.packed)
 
-    bytestrs = list(packed_combinations(tuple(bits), tuple(utf8_lengths)))
+    candidates = filter(
+        lambda bytestr: confusion_check(bytestr, level, confusion_levels, confusion_constraints),
+        packed_combinations(tuple(bits), tuple(utf8_lengths))
+    )
+    bytestrs = list(candidates)
     random.shuffle(bytestrs)
 
     for bytestr in bytestrs:
-        if confusion_check(bytestr, level, confusion_levels, confusion_constraints):
-            return bytestr
+        return bytestr
 
     raise ValueError(f'could not represent given address "{addr}" as valid I-DUNNO at confusion level "{level}"')
 


### PR DESCRIPTION
Some high ipv6 addresses can generate a very large number of potential and good encodings, so I looked at how to limit the number we are evaluating in those cases.

Using a tiny utility class [run.py](https://github.com/andybalaam/i-dunno/blob/improve-worst-case-performance-plus-tests-plus-utils/run.py) to run, with the existing code I get:

```bash
$ time ./run.py '98bc:2980:a3bc:4e48:cad6:5db5:ffd0:3e73'
b'L\xcb\xb0S\x00Q\xdb\xb1\xc7\x89\xf0\xb2\xad\x99\xe7\x9b\x97\x7fP\xe3\xb9\xb3'

real	0m0.101s
user	0m0.085s
sys	0m0.017s
```

This generates 46963 possible encodings, shuffles them, and then picks the first that satisfies the criteria.

Checking the criteria is the hard part, so my solution may not be better, because it checks the criteria on a larger number of items, making sure it has a decent-sized list of good encodings before choosing one.  This makes it slower in the easy cases, but faster in this hard one:

```bash
$ time ./run.py '98bc:2980:a3bc:4e48:cad6:5db5:ffd0:3e73'
b'L/\x05\x18\x05\x0exN$2ZemW\x7fP\xe3\xb9\xb3'

real	0m0.039s
user	0m0.027s
sys	0m0.012s
```

This only generates encodings until it has at least 10 good ones, and then picks one of those.

What do you think?