### PR TITLE
Accept smaller codepoints

### DIFF
--- a/i_dunno/__init__.py
+++ b/i_dunno/__init__.py
@@ -18,7 +18,7 @@ __all__ = ['encode', 'decode']
 __version__ = '0.1.3'
 
 
-utf8_lengths = [(0, 7), (8, 11), (12, 16), (17, 21)]
+utf8_lengths = [(0, 7), (7, 11), (11, 16), (16, 21)]
 
 
 confusion_constraints = {
@@ -65,7 +65,7 @@ def bits_to_bytes(bits):
     return bytes(sum(bit << (7 - idx) for idx, bit in enumerate(aligned_bits[sidx:sidx + 8])) for sidx in range(0, len(aligned_bits), 8))
 
 
-@functools.lru_cache
+@functools.lru_cache()
 def packed_combinations(bits, lengths):
     if not bits:
         return [b'']
@@ -78,7 +78,7 @@ def packed_combinations(bits, lengths):
 
         val = int.from_bytes(bits_to_bytes(bits[:length]), 'big')
 
-        if minimum > 0 and val < (1 << minimum):
+        if val < (1 << minimum):
             continue
 
         try:
@@ -147,11 +147,11 @@ def decode(i_dunno):
         num = ord(char)
 
         for minimum, length in utf8_lengths:
-            if num < (1 << length) and (minimum == 0 or num >= (1 << minimum)):
+            if (1 << minimum) <= num < (1 << length):
                 bits += int_to_bits(num, length)
                 break
         else:
-            raise ValueError('invalid I-DUNNO')
+            raise ValueError(f'invalid I-DUNNO (seen cp={num})')
 
     addr = bits_to_bytes(bits)
 

--- a/tests/test_decode.py
+++ b/tests/test_decode.py
@@ -1,0 +1,49 @@
+import i_dunno
+import ipaddress
+import pytest
+from random import randint
+
+def test_decode():
+    """Decode a form with known antecedent
+
+    Note the last two bytes are UTF for U+00f0 whose binary
+    representation has exactly 8 significant bits.
+    >>> bin(ord(b'\xc3\xb0'.decode("utf-8")))
+    '0b11110000'
+    """
+    form = b'g&\x10\xc3\xb0'
+    v4addr = '206.152.128.240'
+    assert i_dunno.decode(form) == ipaddress.ip_address(v4addr)
+
+def randaddr(af):
+    """Return a random IP address"""
+    if af == "ip":
+        val = randint(1, 2**32 - 1)
+    else:
+        val = randint(2**32, 2**128 - 1)
+    return ipaddress.ip_address(val)
+
+@pytest.mark.parametrize("af, level, nbaddrs", [
+    ("ip",   "minimum",      30),
+    ("ipv6", "minimum",      30),
+    ("ip",   "satisfactory", 30),
+    ("ipv6", "satisfactory", 30),
+    ("ip",   "delightful",   30),
+    ("ipv6", "delightful",   30),
+])
+def test_random(af, level, nbaddrs):
+    """Check decode(encode(addr)) is idempotent for each confusion level"""
+    for i in range(nbaddrs):
+        run_random_one(af, level)
+
+def run_random_one(af, level):
+    """Generate a random address; check decode(encode(addr)) is idempotent"""
+    formfound = False
+    while not formfound:
+        addr = randaddr(af)
+        try:
+            form = i_dunno.encode(addr, level=level)
+            formfound = True
+        except ValueError:
+            continue
+    assert i_dunno.decode(form) == addr

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,6 @@
+[tox]
+envlist = py3
+
+[testenv]
+deps = pytest
+commands = pytest


### PR DESCRIPTION
Hi,

The current code rejects some valid I-DUNNO forms (and never generates a number of valid forms).

Eg. consider codepoints that are represented with exactly 2 octets in UTF-8; those consume 11 bits from the address. These are the codepoints between 2 ** 7 (inclusive) and 2 ** 11 (exclusive). The current code rejects the codepoints between 2 ** 7 and 2 ** 8, since it checks `num >= (1 << minimum))` (where minimum = 8). In addition, the current code sometimes output null octets since, interestingly, the following does not fail: `chr(0).encode('utf-8')`.

Fix the above by reducing by one each minimum value in `utf8_lengths`, and adjusting the comparisons.

I've added some testcases, you can run them by installing tox, and running `tox` (no arguments needed) from the top of the repo.