### PR TITLE
Accept padding

### DIFF
--- a/i_dunno/__init__.py
+++ b/i_dunno/__init__.py
@@ -65,7 +65,7 @@ def bits_to_bytes(bits):
     return bytes(sum(bit << (7 - idx) for idx, bit in enumerate(aligned_bits[sidx:sidx + 8])) for sidx in range(0, len(aligned_bits), 8))
 
 
-@functools.lru_cache
+@functools.lru_cache()
 def packed_combinations(bits, lengths):
     if not bits:
         return [b'']
@@ -153,14 +153,17 @@ def decode(i_dunno):
         else:
             raise ValueError('invalid I-DUNNO')
 
-    addr = bits_to_bytes(bits)
-
-    if len(addr) == 16:
+    max_padding = max(utf8_lengths)[1] - 1
+    if 128 <= len(bits) <= 128 + max_padding:
+        bits = bits[:128]
         cls = ipaddress.IPv6Address
-    elif len(addr) == 4:
+    elif 32 <= len(bits) <= 32 + max_padding:
+        bits = bits[:32]
         cls = ipaddress.IPv4Address
     else:
         raise ValueError('invalid I-DUNNO')
+
+    addr = bits_to_bytes(bits)
 
     try:
         return cls(addr)

--- a/tests/test_padding.py
+++ b/tests/test_padding.py
@@ -1,0 +1,8 @@
+import i_dunno
+import ipaddress
+
+def test_with_padding():
+    """Decode a form that has extra padding"""
+    form = b'S\xef\x99\x94\x1a1\xc7\xa4"w\xe5\xa7\x86\xd0\xb4\xd9\x92\xe9\x85\x8d\xd2\x87\xc2\xae'
+    v6addr = "a7ec:a869:89e4:45dd:671a:1a65:2914:d90e"
+    assert i_dunno.decode(form) == ipaddress.ip_address(v6addr)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,6 @@
+[tox]
+envlist = py3
+
+[testenv]
+deps = pytest
+commands = pytest


### PR DESCRIPTION
Hi,

I-DUNNO forms may contain padding, when you generate a sequence of codepoints where the sum of their lengths is not exactly 32 or 128 (that's the issue #7).

This PR fixes the decoding half of the implementation, by making `decode` ignore the last few bits of the input form, if that form is slightly longer than 32 or 128.